### PR TITLE
Only execute main() if main

### DIFF
--- a/Python/ExtractBOM.py
+++ b/Python/ExtractBOM.py
@@ -74,4 +74,5 @@ def main():
         if ui:
             ui.messageBox('Failed:\n{}'.format(traceback.format_exc()))
 
-main()
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
Added syntax to only execute main() function if the script is the main script. This is often done in Python, and allows for importing the script without execution of main()